### PR TITLE
[Feat] query next batch

### DIFF
--- a/test/query/query_hash_test.go
+++ b/test/query/query_hash_test.go
@@ -81,16 +81,40 @@ func TestQueryHashSimple(t *testing.T) {
 		assert.EqualValues(t, res.Value("c1"), res.Value("c2"))
 		assert.EqualValues(t, "hello", res.Value("c3"))
 	}
+
+	// test NextBatch()
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(5)), table.NewColumn("c2", table.Min)}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(10)), table.NewColumn("c2", table.Max)}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithSelectColumns([]string{"c1", "c2", "c3"}),
+	)
+	assert.Equal(t, nil, err)
+	for res, err := resSet.NextBatch(); err == nil; res, err = resSet.NextBatch() {
+		if res == nil {
+			break
+		}
+		assert.Equal(t, nil, err)
+		for i := 0; i < len(res); i++ {
+			assert.EqualValues(t, res[i].Value("c1"), res[i].Value("c2"))
+			assert.EqualValues(t, "hello", res[i].Value("c3"))
+			assert.EqualValues(t, res[i].Values(), []interface{}{res[i].Value("c1"), res[i].Value("c1"), "hello"})
+		}
+	}
 }
 
 func TestQueryHashBatchSize(t *testing.T) {
 	tableName := queryHashTableName
 	defer test.DeleteTable(tableName)
 
-	recordCount := 10
+	recordCount := 50
 	batchSize := 1
 	prepareHashRecord(recordCount)
 
+	//test Next()
 	startRowKey := []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c2", table.Min)}
 	endRowKey := []*table.Column{table.NewColumn("c1", int64(100)), table.NewColumn("c2", table.Max)}
 	keyRanges := []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
@@ -107,6 +131,30 @@ func TestQueryHashBatchSize(t *testing.T) {
 		assert.Equal(t, nil, err)
 		assert.EqualValues(t, res.Value("c1"), res.Value("c2"))
 		assert.EqualValues(t, "hello", res.Value("c3"))
+	}
+
+	// test NextBatch()
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c2", table.Min)}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(100)), table.NewColumn("c2", table.Max)}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithSelectColumns([]string{"c1", "c2", "c3"}),
+		option.WithBatchSize(batchSize),
+	)
+	assert.Equal(t, nil, err)
+	for res, err := resSet.NextBatch(); err == nil; res, err = resSet.NextBatch() {
+		if res == nil {
+			break
+		}
+		assert.Equal(t, nil, err)
+		for i := 0; i < len(res); i++ {
+			assert.EqualValues(t, res[i].Value("c1"), res[i].Value("c2"))
+			assert.EqualValues(t, "hello", res[i].Value("c3"))
+			assert.EqualValues(t, res[i].Values(), []interface{}{res[i].Value("c1"), res[i].Value("c1"), "hello"})
+		}
 	}
 }
 

--- a/test/query/query_key_test.go
+++ b/test/query/query_key_test.go
@@ -87,7 +87,7 @@ func TestQueryKeyBatchSize(t *testing.T) {
 	tableName := queryKeyTableName
 	defer test.DeleteTable(tableName)
 
-	recordCount := 10
+	recordCount := 50
 	batchSize := 1
 	prepareKeyRecord(recordCount)
 
@@ -107,6 +107,30 @@ func TestQueryKeyBatchSize(t *testing.T) {
 		assert.Equal(t, nil, err)
 		assert.EqualValues(t, res.Value("c1"), res.Value("c2"))
 		assert.EqualValues(t, "hello", res.Value("c3"))
+	}
+
+	// test NextBatch
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c2", table.Min)}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(100)), table.NewColumn("c2", table.Max)}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithSelectColumns([]string{"c1", "c2", "c3"}),
+		option.WithBatchSize(batchSize),
+	)
+	assert.Equal(t, nil, err)
+	for res, err := resSet.NextBatch(); err == nil; res, err = resSet.NextBatch() {
+		if res == nil {
+			break
+		}
+		assert.Equal(t, nil, err)
+		for i := 0; i < len(res); i++ {
+			assert.EqualValues(t, res[i].Value("c1"), res[i].Value("c2"))
+			assert.EqualValues(t, "hello", res[i].Value("c3"))
+			assert.EqualValues(t, res[i].Values(), []interface{}{res[i].Value("c1"), res[i].Value("c1"), "hello"})
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

Implement QueryNext() method for query results.

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

Implement QueryNext() method for query results.

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

Pass all tests in 3.x

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

Notes: NextBatch() could not be used with Next() at the same time.

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information
N.A.
<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
