### PR TITLE
[Fix] single partition query

### DIFF
--- a/client/batch_result_test.go
+++ b/client/batch_result_test.go
@@ -21,14 +21,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/oceanbase/obkv-table-client-go/protocol"
 )
 
 func TestObBatchOperationResult_Size(t *testing.T) {
-	result := protocol.NewObTableOperationResponse()
-	batchResult := newObBatchOperationResult([]*protocol.ObTableOperationResponse{})
+	result := newObSingleResult(1, nil)
+	emptyResult := make([]SingleResult, 0)
+	batchResult := newObBatchOperationResult(emptyResult)
 	assert.EqualValues(t, 0, batchResult.Size())
-	batchResult = newObBatchOperationResult([]*protocol.ObTableOperationResponse{result})
+	batchResult = newObBatchOperationResult([]SingleResult{result})
 	assert.EqualValues(t, 1, batchResult.Size())
 }

--- a/client/query.go
+++ b/client/query.go
@@ -202,7 +202,7 @@ func (q *obQueryExecutor) transferQueryRange() error {
 	return nil
 }
 
-// init calculate the expectant and construct the query result.
+// init calculate the targetParts and construct the query result.
 func (q *obQueryExecutor) init(ctx context.Context) (*ObQueryResultIterator, error) {
 	err := q.checkQueryParams()
 	if err != nil {
@@ -210,7 +210,7 @@ func (q *obQueryExecutor) init(ctx context.Context) (*ObQueryResultIterator, err
 	}
 
 	// get table params
-	expectant, err := q.getTableParams(ctx, q.tableName, q.keyRanges, false)
+	targetParts, err := q.getTableParams(ctx, q.tableName, q.keyRanges, false)
 	if err != nil {
 		return nil, errors.WithMessage(err, "get table params")
 	}
@@ -221,5 +221,5 @@ func (q *obQueryExecutor) init(ctx context.Context) (*ObQueryResultIterator, err
 		return nil, errors.WithMessage(err, "transfer query range")
 	}
 
-	return newObQueryResultIteratorWithParams(ctx, q.cli, q.tableQuery, expectant, q.entityType, q.tableName), nil
+	return newObQueryResultIteratorWithParams(ctx, q.cli, q.tableQuery, targetParts, q.entityType, q.tableName), nil
 }

--- a/example/batch_operation/batch.go
+++ b/example/batch_operation/batch.go
@@ -63,6 +63,6 @@ func main() {
 		panic(err)
 	}
 
-	println(res.GetResults()[0].Entity().GetProperty("c1"))
-	println(res.GetResults()[1].Entity().GetProperty("c2"))
+	println(res.GetResults()[0].Value("c1"))
+	println(res.GetResults()[1].Value("c2"))
 }

--- a/route/column.go
+++ b/route/column.go
@@ -30,5 +30,6 @@ type obColumn interface {
 	CollationType() protocol.ObCollationType
 	// EvalValue calculate the value of the partition column.
 	eval(rowKey []*table.Column) (interface{}, error)
+	extractColumn(rowKey []*table.Column) (*table.Column, error)
 	String() string
 }

--- a/route/generate_column.go
+++ b/route/generate_column.go
@@ -71,6 +71,10 @@ func (c *obGeneratedColumn) eval(rowKey []*table.Column) (interface{}, error) {
 	return nil, errors.New("not support generated column now")
 }
 
+func (c *obGeneratedColumn) extractColumn(rowKey []*table.Column) (*table.Column, error) {
+	return nil, errors.New("not support generated column now")
+}
+
 func (c *obGeneratedColumn) String() string {
 	var objTypeStr = "nil"
 	if c.objType != nil {

--- a/route/hash_partition.go
+++ b/route/hash_partition.go
@@ -96,26 +96,25 @@ func (d *obHashPartDesc) GetPartIds(rowKeyPair *table.RangePair) ([]uint64, erro
 	if rowKeyPair.Start() == nil || rowKeyPair.End() == nil {
 		return nil, errors.New("startKeys or endKeys in rangePair is nil")
 	}
-	if rowKeyPair.IsStartEqEnd() {
-		// check if startKey or endKey is extremum
-		for i := 0; i < len(rowKeyPair.Start()); i++ {
-			if _, ok := rowKeyPair.Start()[i].Value().(table.Extremum); ok {
-				return nil, errors.New("one of startKey or endKey is extremum")
-			}
-		}
-		// startKey == endKey means that the range is equal to a column
-		partId, err := d.GetPartId(rowKeyPair.Start())
-		if err != nil {
-			return []uint64{ObInvalidPartId}, errors.WithMessagef(err, "get part id, part desc:%s", d.String())
-		}
-		return []uint64{partId}, nil
-	} else {
-		// if startKey != endKey, add all partitions to the partition list
+	// extract partition key from range
+	startPk, endPk, err := extractRangePairPartKeyColumns(d, rowKeyPair)
+	if err != nil {
+		return nil, err
+	}
+	// check need to send all partitions
+	if checkQueryPkSendAll(startPk, endPk) {
 		partIds := make([]uint64, 0, d.partNum)
 		for i := 0; i < d.partNum; i++ {
 			partIds = append(partIds, uint64(i))
 		}
 		return partIds, nil
+	} else {
+		// startPk and endPk must be equal after check
+		partId, err := d.GetPartId(startPk)
+		if err != nil {
+			return []uint64{ObInvalidPartId}, errors.WithMessagef(err, "get part id, part desc:%s", d.String())
+		}
+		return []uint64{partId}, nil
 	}
 }
 

--- a/route/simple_column.go
+++ b/route/simple_column.go
@@ -63,6 +63,17 @@ func (c *obSimpleColumn) eval(rowKey []*table.Column) (interface{}, error) {
 	return nil, errors.Errorf("partition column not match, column:%s", c.String())
 }
 
+// extractColumn extract the same column from obSimpleColumn
+func (c *obSimpleColumn) extractColumn(rowKey []*table.Column) (*table.Column, error) {
+	for _, column := range rowKey {
+		if strings.EqualFold(column.Name(), c.columnName) {
+			return column, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (c *obSimpleColumn) String() string {
 	var objTypeStr = "nil"
 	if c.objType != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

Fix send all partitions when the partition key is the same in query.

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

Compare the partition key when calculating the tablet.

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

Pass tests except for index-tests in 4.x

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

N.A.

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

N.A.

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
