### PR TITLE
[Refactor] remove odp sql port

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,7 +70,6 @@ func NewClient(
 // passWord is the password of the fullUserName user.
 // odpIP is the ip of the odp server.
 // odpRpcPort is the rpc port of the odp server.
-// odpSqlPort is the sql port of the odp server.
 // database is the database name which you want to access.
 // cliConfig is the configuration of the client, you can configure based on your business.
 func NewOdpClient(
@@ -78,7 +77,6 @@ func NewOdpClient(
 	passWord string,
 	odpIP string,
 	odpRpcPort int,
-	odpSqlPort int,
 	database string,
 	cliConfig *config.ClientConfig) (Client, error) {
 	// 1. Check args
@@ -93,7 +91,7 @@ func NewOdpClient(
 	}
 
 	// 2. New odp client and init
-	cli, err := newOdpClient(fullUserName, passWord, odpIP, odpRpcPort, odpSqlPort, database, cliConfig)
+	cli, err := newOdpClient(fullUserName, passWord, odpIP, odpRpcPort, database, cliConfig)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "new odp client, odpIP:%s, fullUserName:%s", odpIP, fullUserName)
 	}
@@ -127,7 +125,6 @@ func NewClientWithTomlConfig(configFilePath string) (Client, error) {
 			clientConfig.OdpClientConfig.Password,
 			clientConfig.OdpClientConfig.OdpIp,
 			clientConfig.OdpClientConfig.OdpRpcPort,
-			clientConfig.OdpClientConfig.OdpSqlPort,
 			clientConfig.OdpClientConfig.Database,
 			clientConfig.GetClientConfig(),
 		)

--- a/config/client_config.go
+++ b/config/client_config.go
@@ -51,7 +51,7 @@ func NewDefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		ConnPoolMaxConnSize:              1,
 		ConnConnectTimeOut:               time.Duration(1000) * time.Millisecond,  // 1s
-		ConnLoginTimeout:                 time.Duration(3000) * time.Millisecond,  // 1s
+		ConnLoginTimeout:                 time.Duration(1000) * time.Millisecond,  // 1s
 		OperationTimeOut:                 time.Duration(10000) * time.Millisecond, // 10s
 		LogLevel:                         log.WarnLevel,
 		TableEntryRefreshLockTimeout:     time.Duration(4000) * time.Millisecond, // 4s

--- a/config/client_config.go
+++ b/config/client_config.go
@@ -51,7 +51,7 @@ func NewDefaultClientConfig() *ClientConfig {
 	return &ClientConfig{
 		ConnPoolMaxConnSize:              1,
 		ConnConnectTimeOut:               time.Duration(1000) * time.Millisecond,  // 1s
-		ConnLoginTimeout:                 time.Duration(1000) * time.Millisecond,  // 1s
+		ConnLoginTimeout:                 time.Duration(3000) * time.Millisecond,  // 1s
 		OperationTimeOut:                 time.Duration(10000) * time.Millisecond, // 10s
 		LogLevel:                         log.WarnLevel,
 		TableEntryRefreshLockTimeout:     time.Duration(4000) * time.Millisecond, // 4s

--- a/configurations/obkv-table-default.toml
+++ b/configurations/obkv-table-default.toml
@@ -14,7 +14,6 @@ SysPassword= ""
 [OdpClientConfig]
 OdpIp = ""
 OdpRpcPort = 0
-OdpSqlPort= 0
 FullUserName = ""
 Password = ""
 Database = ""

--- a/obkvrpc/connection.go
+++ b/obkvrpc/connection.go
@@ -181,6 +181,17 @@ func (c *Connection) Login(ctx context.Context) error {
 	c.credential = loginResponse.Credential()
 	c.tenantId = loginResponse.TenantId()
 
+	// Set version if missing
+	if util.ObVersion() == 0.0 && loginResponse.ServerVersion() != "" {
+		// version should be set before login when direct mode
+		version, err := util.ParseObVerionFromLogin(loginResponse.ServerVersion())
+		if err != nil {
+			return errors.WithMessagef(err, "parse ob version from login response, uniqueId: %d remote addr: %s",
+				c.uniqueId, c.conn.RemoteAddr().String())
+		}
+		util.SetObVersion(version)
+	}
+
 	c.active.Store(true)
 	return nil
 }

--- a/obkvrpc/connection.go
+++ b/obkvrpc/connection.go
@@ -146,7 +146,8 @@ func (c *Connection) Connect(ctx context.Context) error {
 	// ez header length rpc header length
 	c.ezHeaderLength = protocol.EzHeaderLength
 	c.rpcHeaderLength = protocol.RpcHeaderEncodeSizeV3
-	if util.ObVersion() >= 4 {
+	if util.ObVersion() >= 4 || util.ObVersion() == 0 {
+		// send as much as we could when we don't know the version
 		c.rpcHeaderLength = protocol.RpcHeaderEncodeSizeV4
 	}
 
@@ -190,6 +191,12 @@ func (c *Connection) Login(ctx context.Context) error {
 				c.uniqueId, c.conn.RemoteAddr().String())
 		}
 		util.SetObVersion(version)
+		// rpc header length rpc header length should be modified if version is missing before login
+		if util.ObVersion() >= 4 {
+			c.rpcHeaderLength = protocol.RpcHeaderEncodeSizeV4
+		} else {
+			c.rpcHeaderLength = protocol.RpcHeaderEncodeSizeV3
+		}
 	}
 
 	c.active.Store(true)

--- a/route/location.go
+++ b/route/location.go
@@ -161,6 +161,11 @@ func GetObVersionFromRemoteByIpPort(ip string, port int, userName string, passwo
 	return GetObVersionFromRemote(db)
 }
 
+// GetObVersionFromOdp get OceanBase cluster version by odp
+func GetObVersionFromOdp(ip string, port int, userName string, password string) (float32, error) {
+	return 0, nil
+}
+
 // GetObVersionFromRemote get OceanBase cluster version by sql
 func GetObVersionFromRemote(db *DB) (float32, error) {
 	// 1. Prepare get observer version sql statement.

--- a/test/query/query_hash_test.go
+++ b/test/query/query_hash_test.go
@@ -44,7 +44,7 @@ func prepareHashRecord(recordCount int) {
 
 func prepareHashSinglePartitionRecord(pk int, recordCount int) {
 	for i := 0; i < recordCount; i++ {
-		insertStatement := fmt.Sprintf("insert into %s(c1, c2) values(%d, %d);", queryHashTableName, pk, i)
+		insertStatement := fmt.Sprintf("insert into %s(c1, c2, c3) values(%d, %d, %s);", queryHashTableName, pk, i, fmt.Sprintf("'hello_%d'", i))
 		test.InsertTable(insertStatement)
 	}
 }
@@ -228,7 +228,7 @@ func TestQueryHashSinglePartition(t *testing.T) {
 	i := 0
 	res, err := resSet.Next()
 	for ; res != nil && err == nil; res, err = resSet.Next() {
-		assert.EqualValues(t, "hello", res.Value("c3"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
 		i++
 	}
 	assert.Equal(t, nil, err)
@@ -268,8 +268,9 @@ func TestQueryHashSinglePartition(t *testing.T) {
 	for ; batchRes != nil && err == nil; batchRes, err = resSet.NextBatch() {
 		assert.Equal(t, nil, err)
 		for i := 0; i < len(batchRes); i++ {
-			assert.EqualValues(t, "hello", batchRes[i].Value("c3"))
-			assert.EqualValues(t, batchRes[i].Values(), []interface{}{int64(pk), int64(i), "hello"})
+			assert.Equal(t, int64(pk), batchRes[i].Value("c1"))
+			assert.Equal(t, int64(i), batchRes[i].Value("c2"))
+			assert.Equal(t, "hello", batchRes[i].Value("c3").(string)[:5])
 		}
 	}
 	assert.Equal(t, nil, err)
@@ -291,7 +292,7 @@ func TestQueryHashSinglePartition(t *testing.T) {
 	res, err = resSet.Next()
 	for ; res != nil && err == nil; res, err = resSet.Next() {
 		assert.Equal(t, nil, err)
-		assert.EqualValues(t, "hello", res.Value("c3"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
 		i++
 	}
 	assert.Equal(t, nil, err)
@@ -318,12 +319,51 @@ func TestQueryHashSinglePartition(t *testing.T) {
 	res, err = resSet.Next()
 	for ; res != nil && err == nil; res, err = resSet.Next() {
 		assert.Equal(t, nil, err)
-		assert.EqualValues(t, "hello", res.Value("c3"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
 		assert.Equal(t, int64(5), res.Value("c2"))
 		i++
 	}
 	assert.Equal(t, nil, err)
 	assert.EqualValues(t, 1, i)
+
+	// test local index
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(pk)), table.NewColumn("c3", "hello_3")}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(pk)), table.NewColumn("c3", "hello_5")}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithQuerySelectColumns([]string{"c1", "c2", "c3"}),
+		option.WithQueryBatchSize(batchSize),
+		option.WithQueryIndexName("i1"),
+	)
+	assert.Equal(t, nil, err)
+	i = 0
+	res, err = resSet.Next()
+	for ; res != nil && err == nil; res, err = resSet.Next() {
+		assert.EqualValues(t, int64(pk), res.Value("c1"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
+		i++
+	}
+	assert.Equal(t, nil, err)
+	assert.EqualValues(t, 3, i)
+
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c3", "not exist")}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c3", "not exist")}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithQuerySelectColumns([]string{"c1", "c2", "c3"}),
+		option.WithQueryBatchSize(batchSize),
+		option.WithQueryIndexName("i1"),
+	)
+	assert.Equal(t, nil, err)
+	res, err = resSet.Next()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, nil, res)
 }
 
 func TestQueryHashBatchSize(t *testing.T) {

--- a/test/query/query_zero_test.go
+++ b/test/query/query_zero_test.go
@@ -44,7 +44,7 @@ func prepareZeroRecord(recordCount int) {
 
 func prepareZeroSinglePartitionRecord(pk int, recordCount int) {
 	for i := 0; i < recordCount; i++ {
-		insertStatement := fmt.Sprintf("insert into %s(c1, c2) values(%d, %d);", queryZeroTableName, pk, i)
+		insertStatement := fmt.Sprintf("insert into %s(c1, c2, c3) values(%d, %d, %s);", queryZeroTableName, pk, i, fmt.Sprintf("'hello_%d'", i))
 		test.InsertTable(insertStatement)
 	}
 }
@@ -148,7 +148,7 @@ func TestQueryZeroSinglePartition(t *testing.T) {
 	i := 0
 	res, err := resSet.Next()
 	for ; res != nil && err == nil; res, err = resSet.Next() {
-		assert.EqualValues(t, "hello", res.Value("c3"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
 		i++
 	}
 	assert.Equal(t, nil, err)
@@ -188,7 +188,9 @@ func TestQueryZeroSinglePartition(t *testing.T) {
 	for ; batchRes != nil && err == nil; batchRes, err = resSet.NextBatch() {
 		assert.Equal(t, nil, err)
 		for i := 0; i < len(batchRes); i++ {
-			assert.EqualValues(t, batchRes[i].Values(), []interface{}{int64(pk), int64(i), "hello"})
+			assert.Equal(t, int64(pk), batchRes[i].Value("c1"))
+			assert.Equal(t, int64(i), batchRes[i].Value("c2"))
+			assert.Equal(t, "hello", batchRes[i].Value("c3").(string)[:5])
 		}
 	}
 	assert.Equal(t, nil, err)
@@ -210,7 +212,7 @@ func TestQueryZeroSinglePartition(t *testing.T) {
 	res, err = resSet.Next()
 	for ; res != nil && err == nil; res, err = resSet.Next() {
 		assert.Equal(t, nil, err)
-		assert.EqualValues(t, "hello", res.Value("c3"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
 		i++
 	}
 	assert.Equal(t, nil, err)
@@ -237,12 +239,51 @@ func TestQueryZeroSinglePartition(t *testing.T) {
 	res, err = resSet.Next()
 	for ; res != nil && err == nil; res, err = resSet.Next() {
 		assert.Equal(t, nil, err)
-		assert.EqualValues(t, "hello", res.Value("c3"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
 		assert.Equal(t, int64(5), res.Value("c2"))
 		i++
 	}
 	assert.Equal(t, nil, err)
 	assert.EqualValues(t, 1, i)
+
+	// test local index
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(pk)), table.NewColumn("c3", "hello_3")}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(pk)), table.NewColumn("c3", "hello_5")}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithQuerySelectColumns([]string{"c1", "c2", "c3"}),
+		option.WithQueryBatchSize(batchSize),
+		option.WithQueryIndexName("i1"),
+	)
+	assert.Equal(t, nil, err)
+	i = 0
+	res, err = resSet.Next()
+	for ; res != nil && err == nil; res, err = resSet.Next() {
+		assert.EqualValues(t, int64(pk), res.Value("c1"))
+		assert.EqualValues(t, "hello", res.Value("c3").(string)[:5])
+		i++
+	}
+	assert.Equal(t, nil, err)
+	assert.EqualValues(t, 3, i)
+
+	startRowKey = []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c3", "not exist")}
+	endRowKey = []*table.Column{table.NewColumn("c1", int64(0)), table.NewColumn("c3", "not exist")}
+	keyRanges = []*table.RangePair{table.NewRangePair(startRowKey, endRowKey)}
+	resSet, err = cli.Query(
+		context.TODO(),
+		tableName,
+		keyRanges,
+		option.WithQuerySelectColumns([]string{"c1", "c2", "c3"}),
+		option.WithQueryBatchSize(batchSize),
+		option.WithQueryIndexName("i1"),
+	)
+	assert.Equal(t, nil, err)
+	res, err = resSet.Next()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, nil, res)
 }
 
 func TestQueryZeroBatchSize(t *testing.T) {

--- a/test/util.go
+++ b/test/util.go
@@ -39,7 +39,6 @@ const (
 	odpFullUserName = "..."
 	odpPassWord     = ""
 	odpRpcPort      = 0
-	odpSqlPort      = 0
 	database        = "..."
 
 	// toml config
@@ -60,7 +59,7 @@ func CreateClient() client.Client {
 	if tomlConfigPath != "" {
 		cli, err = client.NewClientWithTomlConfig(tomlConfigPath)
 	} else if odpIP != "" {
-		cli, err = client.NewOdpClient(odpFullUserName, odpPassWord, odpIP, odpRpcPort, odpSqlPort, database, config.NewDefaultClientConfig())
+		cli, err = client.NewOdpClient(odpFullUserName, odpPassWord, odpIP, odpRpcPort, database, config.NewDefaultClientConfig())
 	} else {
 		cli, err = client.NewClient(configUrl, fullUserName, passWord, sysUserName, sysPassWord, config.NewDefaultClientConfig())
 	}

--- a/util/obversion.go
+++ b/util/obversion.go
@@ -18,6 +18,11 @@
 package util
 
 import (
+	"fmt"
+	"github.com/pkg/errors"
+	"math"
+	"regexp"
+	"strconv"
 	"sync"
 )
 
@@ -32,4 +37,26 @@ func SetObVersion(version float32) {
 	obVersionGuard.Lock()
 	globalObVersion = version
 	obVersionGuard.Unlock()
+}
+
+// ParseObVerionFromLogin may be used in ODP mode
+func ParseObVerionFromLogin(serverVersion string) (float32, error) {
+	// serverVersion is like "OceanBase 4.0.0.0"
+	pattern := "^OceanBase\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$"
+	re := regexp.MustCompile(pattern)
+	match := re.FindStringSubmatch(serverVersion)
+	if len(match) == 5 && match[0] == serverVersion {
+		// transform version into 4.000
+		subVersionStr := match[2] + match[3] + match[4]
+		subVersion, err := strconv.Atoi(subVersionStr)
+		if err != nil {
+			return 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
+		}
+		mainVersion, err := strconv.Atoi(match[1])
+		if err != nil {
+			return 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
+		}
+		return float32(mainVersion) + float32(subVersion)/float32(math.Pow10(len(subVersionStr))), nil
+	}
+	return 0, errors.New(fmt.Sprintf("parse version %s failed", serverVersion))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

- [Refactor] remove ODP SQL port
- [Test] ODP index texts

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

- [Refactor] remove ODP SQL port
- [Test] ODP index texts

<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

Pass all tests in 4.x

<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

SQL port is no longer used in ODP mode.

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

N.A.

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
