### PR TITLE
[Fix] datetime

### DIFF
--- a/test/single/datetime_table_test.go
+++ b/test/single/datetime_table_test.go
@@ -38,8 +38,10 @@ func TestInsertDatetime(t *testing.T) {
 	tableName := testDatetimeTableName
 	defer test.DeleteTable(tableName)
 
-	rowKey := []*table.Column{table.NewColumn("c1", table.DateTime(time.Now().Local()))}
-	mutateColumns := []*table.Column{table.NewColumn("c2", table.DateTime(time.Now().Local()))}
+	rkDateTime := table.DateTime(time.Now().Local())
+	mutDateTime := table.DateTime(time.Now().Local())
+	rowKey := []*table.Column{table.NewColumn("c1", rkDateTime)}
+	mutateColumns := []*table.Column{table.NewColumn("c2", mutDateTime)}
 	affectRows, err := cli.Insert(
 		context.TODO(),
 		tableName,
@@ -57,6 +59,8 @@ func TestInsertDatetime(t *testing.T) {
 		selectColumns,
 	)
 	assert.Equal(t, nil, err)
+	assert.Equal(t, rkDateTime, table.DateTime(result.Value("c1").(time.Time)))
+	assert.Equal(t, mutDateTime, table.DateTime(result.Value("c2").(time.Time)))
 	fmt.Println(result.Value("c1").(time.Time).String())
 	fmt.Println(result.Value("c2").(time.Time).String())
 }

--- a/util/local_time_origin.go
+++ b/util/local_time_origin.go
@@ -15,14 +15,10 @@
  * #L%
  */
 
-package table
+package util
 
 import (
 	"time"
 )
 
-// DateTime from db will be recognize as local timezone, datetime send to server will ignore the timezone.
-type DateTime time.Time
-
-// TimeStamp store in UTC timezone, show in Local timezone.
-type TimeStamp time.Time
+var LocalTimeOrigin time.Time = time.Date(1970, 1, 1, 0, 0, 0, 0, time.Local)


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

- Fix DateTime. 
- **We only care about the time you send to the server without timezone. If you write 2000.01.01 00:00 +8 and 2000.01.01 00:00 +0 into the server, this will be the same. Both Dates will be written as 2000.01.01 00:00 in the server.**
- **When we get a DateTime from the server, we will recognize it as a time from the local timezone.**



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
- Fix DateTime. 
