### PR TITLE
bugfix : offset can not use without limit value

### DIFF
--- a/client/query.go
+++ b/client/query.go
@@ -187,6 +187,9 @@ func (q *obQueryExecutor) checkQueryParams() error {
 	if q.tableQuery == nil {
 		return errors.New("table query is nil")
 	}
+	if q.tableQuery.Limit() == -1 && q.tableQuery.Offset() != 0 {
+		return errors.New("unexpected offset without limit")
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
offset can not use without limit value
## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
offset can not use without limit value


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
offset can not use without limit value