### PR TITLE
fix: query with primary index used indexName 'primary'

### DIFF
--- a/client/query.go
+++ b/client/query.go
@@ -20,6 +20,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/oceanbase/obkv-table-client-go/client/option"
 	"github.com/oceanbase/obkv-table-client-go/route"
@@ -201,7 +202,7 @@ func (q *obQueryExecutor) init(ctx context.Context) (*ObQueryResultIterator, err
 
 	// construct index table name if do index scan
 	tableName := q.tableName
-	if q.cli.odpTable == nil && "" != q.tableQuery.IndexName() {
+	if q.cli.odpTable == nil && "" != q.tableQuery.IndexName() && !strings.EqualFold(q.tableQuery.IndexName(), "primary") {
 		indexTableName, err := q.cli.routeInfo.ConstructIndexTableName(ctx, tableName, q.tableQuery.IndexName())
 		if err != nil {
 			return nil, errors.WithMessage(err, "construct index table name")


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
bugfix: query with primary index used indexName 'primary'


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
when indexName use 'primary' will do query with primary index