### PR TITLE
expose error code of ObProtocolError

### DIFF
--- a/protocol/error.go
+++ b/protocol/error.go
@@ -58,3 +58,7 @@ func (e *ObProtocolError) Error() string {
 		e.trace,
 	)
 }
+
+func (e *ObProtocolError) ErrorCode() error2.ObErrorCode {
+	return e.errCode
+}


### PR DESCRIPTION
It is comman that clients would like to figure out what kind of errors they have received.