### PR TITLE
Fix odp 436 version incompatible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/obkvrpc/connection.go
+++ b/obkvrpc/connection.go
@@ -190,12 +190,13 @@ func (c *Connection) Login(ctx context.Context) error {
 	// Set version if missing
 	if util.ObVersion() == 0.0 && loginResponse.ServerVersion() != "" {
 		// version should be set before login when direct mode
-		version, err := util.ParseObVerionFromLogin(loginResponse.ServerVersion())
+		obVersion, odpVersion, err := util.ParseObVerionFromLogin(loginResponse.ServerVersion())
 		if err != nil {
 			return errors.WithMessagef(err, "parse ob version from login response, uniqueId: %d remote addr: %s",
 				c.uniqueId, c.conn.RemoteAddr().String())
 		}
-		util.SetObVersion(version)
+		util.SetObVersion(obVersion)
+		util.SetOdpVersion(odpVersion)
 		// rpc header length rpc header length should be modified if version is missing before login
 		if util.ObVersion() >= 4 {
 			c.rpcHeaderLength = protocol.RpcHeaderEncodeSizeV4

--- a/util/obversion.go
+++ b/util/obversion.go
@@ -96,5 +96,5 @@ func ParseObVerionFromLogin(serverVersion string) (float32, float32, error) {
 
 		return obVersion, odpVersion, nil
 	}
-	return 0, 0, errors.New(fmt.Sprintf("parse version %s failed 5", serverVersion))
+	return 0, 0, errors.New(fmt.Sprintf("parse version %s failed", serverVersion))
 }

--- a/util/obversion.go
+++ b/util/obversion.go
@@ -19,15 +19,17 @@ package util
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 var globalObVersion float32 = 0.0
+var globalOdpVersion float32 = 0.0
 var obVersionGuard sync.Mutex
 
 func ObVersion() float32 {
@@ -40,30 +42,57 @@ func SetObVersion(version float32) {
 	obVersionGuard.Unlock()
 }
 
+func SetOdpVersion(version float32) {
+	obVersionGuard.Lock()
+	globalOdpVersion = version
+	obVersionGuard.Unlock()
+}
+
+func OdpVersion() float32 {
+	return globalOdpVersion
+}
+
 // ParseObVerionFromLogin may be used in ODP mode
-func ParseObVerionFromLogin(serverVersion string) (float32, error) {
+func ParseObVerionFromLogin(serverVersion string) (float32, float32, error) {
 	pattern := ""
 	if strings.HasPrefix(serverVersion, "OceanBase_CE") {
-		// serverVersion is like "OceanBase_CE 4.0.0.0" in CE
-		pattern = "^OceanBase_CE\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$"
+		// serverVersion in CE is like "OceanBase_CE 4.0.0.0 (+ Obproxy 4.3.6.0), content in () is optional and valid after Obproxy 4.3.5"
+		pattern = "^OceanBase_CE\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)(\\s+\\+\\s+(Obproxy)\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+))?"
 	} else {
-		// serverVersion is like "OceanBase 4.0.0.0"
-		pattern = "^OceanBase\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$"
+		// serverVersion is like "OceanBase 4.0.0.0 (+ Obproxy 4.3.6.0), content in () is optional and valid after Obproxy 4.3.5"
+		pattern = "^OceanBase\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)(\\s+\\+\\s+(Obproxy)\\s+(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+))?"
 	}
 	re := regexp.MustCompile(pattern)
 	match := re.FindStringSubmatch(serverVersion)
-	if len(match) == 5 && match[0] == serverVersion {
-		// transform version into 4.000
+	if (len(match) == 5 || len(match) == 11) && match[0] == serverVersion {
+		// transform ob version into 4.000
 		subVersionStr := match[2] + match[3] + match[4]
 		subVersion, err := strconv.Atoi(subVersionStr)
 		if err != nil {
-			return 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
+			return 0, 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
 		}
 		mainVersion, err := strconv.Atoi(match[1])
 		if err != nil {
-			return 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
+			return 0, 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
 		}
-		return float32(mainVersion) + float32(subVersion)/float32(math.Pow10(len(subVersionStr))), nil
+		obVersion := float32(mainVersion) + float32(subVersion)/float32(math.Pow10(len(subVersionStr)))
+
+		// transform odp version into 4.360 if present
+		var odpVersion float32 = 0
+		if len(match) == 11 {
+			subOdpVersionStr := match[8] + match[9] + match[10]
+			subOdpVersion, err := strconv.Atoi(subOdpVersionStr)
+			if err != nil {
+				return 0, 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
+			}
+			mainOdpVersion, err := strconv.Atoi(match[7])
+			if err != nil {
+				return 0, 0, errors.WithMessagef(err, "parse version %s failed", serverVersion)
+			}
+			odpVersion = float32(mainOdpVersion) + float32(subOdpVersion)/float32(math.Pow10(len(subOdpVersionStr)))
+		}
+
+		return obVersion, odpVersion, nil
 	}
-	return 0, errors.New(fmt.Sprintf("parse version %s failed", serverVersion))
+	return 0, 0, errors.New(fmt.Sprintf("parse version %s failed", serverVersion))
 }

--- a/util/obversion.go
+++ b/util/obversion.go
@@ -64,7 +64,9 @@ func ParseObVerionFromLogin(serverVersion string) (float32, float32, error) {
 	}
 	re := regexp.MustCompile(pattern)
 	match := re.FindStringSubmatch(serverVersion)
-	if (len(match) == 5 || len(match) == 11) && match[0] == serverVersion {
+	// match length is always 11 when matched successfully (10 capture groups + match[0])
+	// match[5] is empty when Obproxy part is not present
+	if len(match) == 11 && match[0] == serverVersion {
 		// transform ob version into 4.000
 		subVersionStr := match[2] + match[3] + match[4]
 		subVersion, err := strconv.Atoi(subVersionStr)
@@ -77,9 +79,9 @@ func ParseObVerionFromLogin(serverVersion string) (float32, float32, error) {
 		}
 		obVersion := float32(mainVersion) + float32(subVersion)/float32(math.Pow10(len(subVersionStr)))
 
-		// transform odp version into 4.360 if present
+		// transform odp version if present
 		var odpVersion float32 = 0
-		if len(match) == 11 {
+		if match[5] != "" && match[6] != "" {
 			subOdpVersionStr := match[8] + match[9] + match[10]
 			subOdpVersion, err := strconv.Atoi(subOdpVersionStr)
 			if err != nil {
@@ -94,5 +96,5 @@ func ParseObVerionFromLogin(serverVersion string) (float32, float32, error) {
 
 		return obVersion, odpVersion, nil
 	}
-	return 0, 0, errors.New(fmt.Sprintf("parse version %s failed", serverVersion))
+	return 0, 0, errors.New(fmt.Sprintf("parse version %s failed 5", serverVersion))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
ODP 436 appends new String part after Oceanbase Version, which causes incompatibility of the current version matching.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Fix the version matching regex.